### PR TITLE
[Modify] model/tweet.rb & model/tag.rb

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
 class Tag < ApplicationRecord
 	has_many :tweet_tags, dependent: :destroy
-	has_many :tweets, through: :tweet_tags
+	has_many :tweets, through: :tweet_tags, dependent: :destroy
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,8 +1,8 @@
 class Tweet < ApplicationRecord
 	belongs_to :user
 
-	has_many :tweet_tags
-	has_many :tags, through: :tweet_tags
+	has_many :tweet_tags, dependent: :destroy
+	has_many :tags, through: :tweet_tags, dependent: :destroy
 
 	after_create do
 		tags = self.body.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー]+/)


### PR DESCRIPTION
タグ付きのツイートが削除出来なかったので修正
原因
・tweetモデルとtagモデルに　dependent: destroyを記述していなかった為
（model/tweet.rb、model/tag.rbにdependent: destroy追記)